### PR TITLE
Added serialized size to version string

### DIFF
--- a/kids/kid0003.md
+++ b/kids/kid0003.md
@@ -98,18 +98,21 @@ minor increments with backward compatible changes
 
 Serialize event with 0000 size value in version string.
 
+```
 KERI_cbor_0000_1.0
 KERI_json_0000_1.0
 KERI_mgpk_0000_1.0
+```
 
+Then replace the 0000 size field inside the version string  of the serialized event with lowercase hex of actual size of serialized event.
 
-Then replace size with lowercase hex of actual serialized event and replace version string inside serialized event.
-
+```
 KERI_cbor_00fe_1.0
 KERI_json_01c2_1.0
 KERI_mgpk_00fe_1.0
+```
 
-Then sign the encoded event with correct size.
+Then sign the encoded event that now has the correct size in its version string.
 
 
 ### Inception Event

--- a/kids/kid0003.md
+++ b/kids/kid0003.md
@@ -78,16 +78,38 @@ sigs = signature offset list (all)
 
 ### Version String
 
-KERI_cbor_1.0
-KERI_json_1.0
-KERI_mgpk_1.0
+Version string enables discovery of encoding when parsing serialized
+packet.
 
-version number string  = 1.0  = major.minor
+
+Parts:
+    KERI_encoding_size_version
+    KERI = KERI event packet identifier
+    encoding = one of cbor, json, mgpk
+    size = 4 character hex string length of serialized event 
+           max size 65535 bytes in version 1.0
+    version = major.minor = 1.0
+
+
 version tuple = (1, 0) = (major, minor)
 
 major increments with backward breaking changes
 minor increments with backward compatible changes
 
+Serialize event with 0000 size value in version string.
+
+KERI_cbor_0000_1.0
+KERI_json_0000_1.0
+KERI_mgpk_0000_1.0
+
+
+Then replace size with lowercase hex of actual serialized event and replace version string inside serialized event.
+
+KERI_cbor_00fe_1.0
+KERI_json_01c2_1.0
+KERI_mgpk_00fe_1.0
+
+Then sign the encoded event with correct size.
 
 
 ### Inception Event
@@ -95,7 +117,7 @@ minor increments with backward compatible changes
 
 ```javascript
 {
-  "vs"   : "KERI_json_1.0",
+  "vs"   : "KERI_json_00fe_1.0",
   "id"   : "AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",  // qualified Base64
   "sn"   : "0",  // hex string no leading zeros
   "ilk"  : "icp",
@@ -115,7 +137,7 @@ minor increments with backward compatible changes
 
 ```javascript
 {
-  "vs"   : "KERI_json_1.0",
+  "vs"   : "KERI_json_01c2_1.0",
   "id"   : "AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",  // qualified Base64
   "sn"   : "1",  // hex string no leading zeros
   "ilk"  : "rot",
@@ -136,7 +158,7 @@ minor increments with backward compatible changes
 
 ```javascript
 {
-  "vs"   : "KERI_json_1.0",
+  "vs"   : "KERI_json_00df_1.0",
   "id"   : "AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",  // qualified Base64
   "sn"   : "1",  // hex string no leading zeros
   "ilk"  : "ixn",
@@ -151,7 +173,7 @@ minor increments with backward compatible changes
 
 ```javascript
 {
-  "vs"   : "KERI_json_1.0",
+  "vs"   : "KERI_json_01f4_1.0",
   "id"   : "AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",  // qualified Base64
   "sn"   : "0",  // hex string no leading zeros
   "ilk"  : "dip",
@@ -177,7 +199,7 @@ minor increments with backward compatible changes
 
 ```javascript
 {
-  "vs"   : "KERI_json_1.0",
+  "vs"   : "KERI_json_02fe_1.0",
   "id"   : "AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",  // qualified Base64
   "sn"   : "1",  // hex string no leading zeros
   "ilk"  : "drt",


### PR DESCRIPTION
In order to make is simple and universally possible to extract signatures attached to serialized events for non http transport protocols, added 4 hex character size to  version string.

This limits size of KERI events to 65535 bytes. This seems to be more than enough for KERI version 1.0 events and can be increased in later versions if need be.