### PR TITLE
2.4.3 b

### DIFF
--- a/kids/kid0003.md
+++ b/kids/kid0003.md
@@ -64,7 +64,7 @@ In the following specifications the element sets are expressed in JSON format. B
 ### Element Labels
 
 vs   = version string (all)  
-aid  = autonmic identifier prefix (all)  
+pre  = autonomic identifier prefix (all)  
 sn   = sequence number (all)  
 ilk  = event ilk type (all)  
 dig  = digest previous event (rot, ixn, drt)  
@@ -153,7 +153,7 @@ In conclusion, the design decision here is that an or-ing of value types in a se
 ```javascript
 {
   "vs"   : "KERI10JSON00011c_",
-  "aid"  : "AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",  // qualified Base64
+  "pre"  : "AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",  // qualified Base64
   "sn"   : "0",  // lowercase hex string no leading zeros
   "ilk"  : "icp",
   "sith" : "1",  // lowercase hex string no leading zeros or list
@@ -172,7 +172,7 @@ In conclusion, the design decision here is that an or-ing of value types in a se
 ```javascript
 {
   "vs"   : "KERI10JSON00011c_",
-  "aid"  : "AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",  // qualified Base64
+  "pre"  : "AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",  // qualified Base64
   "sn"   : "1",  // lowercase hex string no leading zeros
   "ilk"  : "rot",
   "dig"  : "DZ-i0d8JZAoTNZH3ULvaU6JR2nmwyYAfSVPzhzS6b5CM",  // qualified Base64
@@ -192,7 +192,7 @@ In conclusion, the design decision here is that an or-ing of value types in a se
 ```javascript
 {
   "vs"   : "KERI10JSON00011c_",
-  "aid"  : "AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",  // qualified Base64
+  "pre"  : "AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",  // qualified Base64
   "sn"   : "1",  // lowercase hex string no leading zeros
   "ilk"  : "ixn",
   "dig"  : "DZ-i0d8JZAoTNZH3ULvaU6JR2nmwyYAfSVPzhzS6b5CM",  // qualified Base64
@@ -206,7 +206,7 @@ In conclusion, the design decision here is that an or-ing of value types in a se
 ```javascript
 {
   "vs"   : "KERI10JSON00011c_",
-  "aid"  : "AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",  // qualified Base64
+  "pre"  : "AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",  // qualified Base64
   "sn"   : "1",  // lowercase hex string no leading zeros
   "ilk"  : "ixn",
   "dig"  : "DZ-i0d8JZAoTNZH3ULvaU6JR2nmwyYAfSVPzhzS6b5CM",  // qualified Base64
@@ -227,7 +227,7 @@ In conclusion, the design decision here is that an or-ing of value types in a se
 ```javascript
 {
   "vs"   : "KERI10JSON00011c_",
-  "aid"  : "AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",  // qualified Base64
+  "pre"  : "AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",  // qualified Base64
   "sn"   : "1",  // lowercase hex string no leading zeros
   "ilk"  : "rot",
   "dig"  : "DZ-i0d8JZAoTNZH3ULvaU6JR2nmwyYAfSVPzhzS6b5CM",  // qualified Base64
@@ -253,7 +253,7 @@ In conclusion, the design decision here is that an or-ing of value types in a se
 ```javascript
 {
   "vs"   : "KERI10JSON00011c_",
-  "aid"  : "AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",  // qualified Base64
+  "pre"  : "AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",  // qualified Base64
   "sn"   : "0",  // lowercase hex string no leading zeros
   "ilk"  : "dip",
   "sith" : "1",  // lowercase hex string no leading zeros or list
@@ -279,7 +279,7 @@ In conclusion, the design decision here is that an or-ing of value types in a se
 ```javascript
 {
   "vs"   : "KERI10JSON00011c_",
-  "aid"  : "AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",  // qualified Base64
+  "pre"  : "AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",  // qualified Base64
   "sn"   : "1",  // lowercase hex string no leading zeros
   "ilk"  : "drt",
   "dig"  : "DZ-i0d8JZAoTNZH3ULvaU6JR2nmwyYAfSVPzhzS6b5CM",  // qualified Base64
@@ -307,7 +307,7 @@ In conclusion, the design decision here is that an or-ing of value types in a se
 ```javascript
 {
   "vs"   : "KERI10JSON00011c_",
-  "aid"  : "AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",  // qualified Base64
+  "pre"  : "AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",  // qualified Base64
   "sn"   : "1",  // lowercase hex string no leading zeros
   "ilk"  : "ixn",
   "dig"  : "DZ-i0d8JZAoTNZH3ULvaU6JR2nmwyYAfSVPzhzS6b5CM",  // qualified Base64
@@ -323,7 +323,7 @@ In conclusion, the design decision here is that an or-ing of value types in a se
 ```javascript
 {
   "vs"   : "KERI10JSON00011c_",
-  "aid"  : "AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",  // qualified Base64
+  "pre"  : "AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",  // qualified Base64
   "sn"   : "1",  // lowercase hex string no leading zeros
   "ilk"  : "rct",
   "dig"  : "DZ-i0d8JZAoTNZH3ULvaU6JR2nmwyYAfSVPzhzS6b5CM",  // qualified Base64 Optional
@@ -449,7 +449,7 @@ Fields
 
 ```javascript
 [
-  "aid",
+  "pre",
   "sn",   
   "dig" 
 ]
@@ -459,7 +459,7 @@ Fields
 
 ```javascript
 {
-  "aid"   : "AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",  // qualified Base64
+  "pre"   : "AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",  // qualified Base64
   "sn"   : "1",  // hex string no leading zeros
   "dig"  : "DZ-i0d8JZAoTNZH3ULvaU6JR2nmwyYAfSVPzhzS6b5CM",  // qualified Base64
 }
@@ -471,7 +471,7 @@ Fields
 
 ```javascript
 [
-  "aid",  // delegating event
+  "pre",  // delegating event
   "sn",   // delegating event
   "ilk",  // delegating event
   "dig"   // delegating event of previous event
@@ -482,7 +482,7 @@ Fields
 
 ```javascript
 {
-  "aid"  : "AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",  // qualified Base64
+  "pre"  : "AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",  // qualified Base64
   "sn"   : "1",  // hex string no leading zeros
   "ilk"  : "ixn",
   "dig"  : "DZ-i0d8JZAoTNZH3ULvaU6JR2nmwyYAfSVPzhzS6b5CM",  // qualified Base64


### PR DESCRIPTION
Changed "aid" label to "pre" label to prevent future confusion. In KERI events the element is the autonomic identifier prefix only not the full autonomic identifier. Later in other parts of KERI when will start using full aids it will be confusing that the event field label for merely the prefix is aid not something more evocative of prefix like "pre"