### PR TITLE
2.4.4

### DIFF
--- a/kids/kid0003.md
+++ b/kids/kid0003.md
@@ -378,6 +378,7 @@ But the "keys" element is itself a list. So the concatenated data will be the "s
 
 ```javascript
 [
+  "vs",
   "sn",
   "ilk",
   "sith",
@@ -395,6 +396,7 @@ But the "keys" element is itself a list. So the concatenated data will be the "s
 
 ```javascript
 [
+  "vs",    // delegated event
   "sn",    // delegated event
   "ilk",   // delegated event
   "sith",  // delegated event


### PR DESCRIPTION
Added "vs" back into extracted element label lists for prefixes. So that only one inception event of a given version and serialization may result in a given self-addressing/self-signing digest/sig identifier prefix.