### PR TITLE
Change delegated event definitions

### DIFF
--- a/kids/kid0003.md
+++ b/kids/kid0003.md
@@ -8,7 +8,7 @@ email: sam@samuelsmith.org
 [![hackmd-github-sync-badge](https://hackmd.io/yd8X2Z5JRW2g9FI73h93xQ/badge)](https://hackmd.io/yd8X2Z5JRW2g9FI73h93xQ)
 
 
-(See WhitePaper Version 2.54)
+(See WhitePaper Version 2.55)
 
 There are two serialization algorithms needed for KERI. The first is the serialization of full events.  The second is the serialization of data sets extracted from a full event. 
 
@@ -591,6 +591,33 @@ Fields
   "dig"  : "DZ-i0d8JZAoTNZH3ULvaU6JR2nmwyYAfSVPzhzS6b5CM",  // qualified Base64 prefix of event prior to located event (prior event to delegating event)
 }
 ```
+
+## Inception Configuration Traits
+
+The naming of these as a "trait" was orginally motivated by a desire to avoid confusion with  the words attribute and property refer to elements associated with objects (namely Python objects). However in other languages like Rust the word trait is also used. Another synonym "aspect" is used in other languages as well. So given there may not be a word with conflict, trait, is used because it is short. Given that the curren trait is a constraint a suggested approch is to change the term to "curb" which does not conflict with any language terms.
+
+Inception configuration traits only show up in the 'cnfg' element of the inception and delegated inception events.
+
+So far the only configuation trait defined for KERI is the following:
+
+```python
+'EstOnly'
+```
+
+The inception EstOnly trait, when present places a constraint on the key event stream that only allows  establishment events. Or in other words interaction events are not allowed. This provides the best case security because signing keys become one use only and therefore minimizes the potential for exploit of signing keys.
+
+To apply a trait include a mapping of the following form in the cnfg element list. Where the mapping has one element with key = 'trait' and value is the trait string. In this case value = 'EstOnly'. For example:
+
+```json
+{
+
+"confg": [{"trait":  "EstOnly"}]
+}
+```
+
+Each trait string must be unique.
+
+In delegated inception events additional traits may be defined for constraints on permissions. A suggested constraint maybe "DoNotDelegate" or "NoDel" to forbid the delegated event stream from creating delegations of other event streams.
 
 
 

--- a/kids/kid0003.md
+++ b/kids/kid0003.md
@@ -8,7 +8,7 @@ email: sam@samuelsmith.org
 [![hackmd-github-sync-badge](https://hackmd.io/yd8X2Z5JRW2g9FI73h93xQ/badge)](https://hackmd.io/yd8X2Z5JRW2g9FI73h93xQ)
 
 
-(See WhitePaper Version 2.53)
+(See WhitePaper Version 2.54)
 
 There are two serialization algorithms needed for KERI. The first is the serialization of full events.  The second is the serialization of data sets extracted from a full event. 
 
@@ -222,8 +222,8 @@ In conclusion, the design decision here is that an or-ing of value types in a se
   "dig"  : "DZ-i0d8JZAoTNZH3ULvaU6JR2nmwyYAfSVPzhzS6b5CM",  // qualified Base64
   "data" : [
              {
-               "pre"  : "AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",  // qual Base64
-               "dig" : "DZ-i0d8JZAoTNZH3ULvaU6JR2nmwyYAfSVPzhzS6b5CM",  // qual Base64
+               "pre"  : "AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",  // qual Base64 prefixe of delegated event stream
+               "dig" : "DZ-i0d8JZAoTNZH3ULvaU6JR2nmwyYAfSVPzhzS6b5CM",  // qual Base64 digest of delegated event
              }
            ]  // list of seal ordered mappings
 }
@@ -248,8 +248,8 @@ In conclusion, the design decision here is that an or-ing of value types in a se
   "adds" : [],  // list of qualified Base64
   "data" : [
              {
-               "pre"  : "AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",  // qual Base64
-               "dig" : "DZ-i0d8JZAoTNZH3ULvaU6JR2nmwyYAfSVPzhzS6b5CM",  // qual Base64
+               "pre"  : "AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",  // qual Base64 prefix of delegated event stream
+               "dig" : "DZ-i0d8JZAoTNZH3ULvaU6JR2nmwyYAfSVPzhzS6b5CM",  // qual Base64 digest of delegated event
              }
            ]  // list of seal ordered mappings
 }
@@ -269,7 +269,7 @@ In conclusion, the design decision here is that an or-ing of value types in a se
   "nxt"  : "DZ-i0d8JZAoTNZH3ULvaU6JR2nmwyYAfSVPzhzS6b5CM",  // qualified Base64
   "toad" : "1",  // lowercase hex string no leading zeros
   "wits" : [],  // list of qualified Base64
-  "perm" : [],   // list of ordered mappings of delegation permissions
+  "cnfg" : [],   // list of ordered mappings of inception configuration including permissions
   "seal" : 
            {
              "pre"  : "AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",  // qual Base64 delegator
@@ -297,7 +297,7 @@ In conclusion, the design decision here is that an or-ing of value types in a se
   "toad" : "1",  // lowercase hex string no leading zeros
   "cuts" : [],  // list of qualified Base64
   "adds" : [],  // list of qualified Base64
-  "perm" : [],   // list of ordered mappings of delegation permissions
+  "data" : [],   // list of ordered mappings of seals for anchoring data
   "seal" : 
            {
              "pre"  : "AmwyZ-i0d8JZaU6JR2nAoTNZH3ULvYAfSVPzhzS6b5CM",  // qual Base64 delegator
@@ -528,7 +528,7 @@ Fields
 
 ```javascript
 {
-  "dig"  : "DZ-i0d8JZAoTNZH3ULvaU6JR2nmwyYAfSVPzhzS6b5CM",  // qualified Base64
+  "dig"  : "DZ-i0d8JZAoTNZH3ULvaU6JR2nmwyYAfSVPzhzS6b5CM",  // qualified Base64 digest of anchored data
 }
 ```
 
@@ -538,7 +538,7 @@ Fields
 
 ```javascript
 [ 
-  "root"
+  "root" 
 ]
 ```
 
@@ -546,7 +546,7 @@ Fields
 
 ```javascript
 {
-  "root"  : "DZ-i0d8JZAoTNZH3ULvaU6JR2nmwyYAfSVPzhzS6b5CM",  // qualified Base64
+  "root"  : "DZ-i0d8JZAoTNZH3ULvaU6JR2nmwyYAfSVPzhzS6b5CM",  // qualified Base64 digest of sparse Merkle tree root
 }
 ```
 
@@ -563,8 +563,8 @@ Fields
 
 ```javascript
 {
-  "pre"   : "AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",  // qualified Base64
-  "dig"  : "DZ-i0d8JZAoTNZH3ULvaU6JR2nmwyYAfSVPzhzS6b5CM",  // qualified Base64
+  "pre"   : "AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",  // qualified Base64 identifer prefix of event stream
+  "dig"  : "DZ-i0d8JZAoTNZH3ULvaU6JR2nmwyYAfSVPzhzS6b5CM",  // qualified Base64 digest of event
 }
 ```
 
@@ -585,10 +585,10 @@ Fields
 
 ```javascript
 {
-  "pre"  : "AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",  // qualified Base64
-  "sn"   : "1",  // hex string no leading zeros
-  "ilk"  : "ixn",
-  "dig"  : "DZ-i0d8JZAoTNZH3ULvaU6JR2nmwyYAfSVPzhzS6b5CM",  // qualified Base64
+  "pre"  : "AaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",  // qualified Base64 identifer prefix of event stream of located event (delegating event)
+  "sn"   : "1",  // hex string no leading zeros of located event (delegating event)
+  "ilk"  : "ixn",  // string of event ilk of located event (delegating event)
+  "dig"  : "DZ-i0d8JZAoTNZH3ULvaU6JR2nmwyYAfSVPzhzS6b5CM",  // qualified Base64 prefix of event prior to located event (prior event to delegating event)
 }
 ```
 

--- a/kids/kid0003Comment.md
+++ b/kids/kid0003Comment.md
@@ -7,6 +7,8 @@ email: sam@samuelsmith.org
 
 [![hackmd-github-sync-badge](https://hackmd.io/LdDZLLQvSxml3k3ND7jFZg/badge)](https://hackmd.io/LdDZLLQvSxml3k3ND7jFZg)
 
+version 1.02
+
 
 The KERI approach is that the over-the-wire serialization of the key event message is completely encompassed by the attached signatures. Likewise digests that chain one key event message to another completely encompass the over-the-wire serializaton of the chained digested key event message. We call this property zero message malleability. Moreover, because each message is signed, the signature protects the embedded chaining digest.
 
@@ -22,4 +24,28 @@ Zero transaction malleability does not prevent a malicious or faulty conroller f
 KERI is opinionated about security. The best practice for locking down any semantic leakage is to fully encompass the over-the-wire key event message with the signatures and digests not some subset of the data. 
 
 Zero message malleability is somewhat inconvenient when generating and parsing the over-the-wire serializations but it is an intentional trade-off that reflects KERI's security first aesthetic.
+
+## Semantic Leakage
+
+We define semantic leakage to occur whan any part of an over the wire message that contributes any meaning or function that affects the behavior of the protocol but is not wrapped in a signature. Often this might be a header or some optional part of a message. A message with semantic leakage is inherently vulnerable to probing attacks. Its just asking for trouble.
+
+Zero Message Malleability, is a specific design feature that says completely wrap over the wire messages with a signature(s).  Many protocols employs MACs Hashes and Signatures but make optimizations that result in not wrapping the full over the wire message. This exposes them to semantic leakage. It is one of the most insidious and difficult to detect types of vulnerabilities. Bitcoin still suffers from new transaction malleability attacks as do many protocols such as SSL. Until those protocols achieve ZMM they will contintue to be vulnerable.
+
+## Probing Attacks
+
+In a protocol where some parts of the over the wire message (say a header or an optional block) is not wrapped by the signature, i.e. does not have ZMM, then a probe attack is enabled where an attacker can send different messages but whose signatures still verify. These different messages may elicit different responses. These become a means of discovering defects in an implementation without having to compromise keys. Compromizing keys is hard. Its not susceptible to probing attacks if those keys are full 128 bit cryptographic strength. KERI's ZMM makes such attacks, i.e. probing attacks without compromising signatures, impossible.
+
+
+ZMM does not protect against a malicious controller. In KERI the duplicity detection protects against malicious controllers. A malicious controller has access to the keys and may therefore create and sign messages at will. But that controller may not create duplicitous messages without risking detection.
+
+For example if a given validator's implementation of KERI has defects in it then a malicious controller can send messages that are fully wrapped in verifiable signatures but the contents somehow expose an error in the validators implementation. Typically incorrelty implemented validation logic. A trivial example would be non-sequential sequence numbers. If a validator's code did not check for sequential sequence numbers then it would create a malformed KEL that some other validator would reject.
+
+## Formal Schema
+
+One of the reasons that many protocols with flexible message structure use formal schema descriptions is to avoid vulnerabilities that may arise from inadvertent semantic leakage when the protocol does not have ZMM.  Inadvertent semantic leakage may arise over time as the protocol features are changed. We call this semantic drift.  ZMM means that inadvertent leakage is not possible, hence semantic drift is less dangerous. In spite of semantic drift a ZMM protocol is not vulnerable to external probing attack without compromise of keys.  
+
+
+
+
+
 


### PR DESCRIPTION
After doing the work of implementing delegated events on the keripy repo, and parallel work on semantics for embedding delegated authorizations in verifiable credentials,  I discovered some good reasons to change the existing definitions for delegated events. The proposed changes are as follows:

Remove the perm element from the delegated events.

Add in a cnfg element to the delegated inception  (or replace the perm element with a cnfg element)

Add in a data element to the delegated rotation (or replace the perm element with a data element)

Reasons for the change:

1) VCs with embeded authorizations are a better place for general flexible schema and semantics for authorizations.
KERI is all about establishing control authority and key management to do that with. Delegated identifiers main purpose is to enable the use of multi-valent key management infrastructure. The meaning of "delegation" in this sense is delegating  control authority  to a different key management infrastructure. The purpose is to make a trade-off between security and performance of key management infrastructure while still providing recovery of key compromise at the higher layer. Thus delegation provides a nested recovery wrapper around less secure but more performant delegated identifiers. 

2) In contradistinction delegated identifiers are not meant to convey general purpose delegation or delegated authorization logic. That is better reserved for VC with delegating authorization semantics and schema..  As a result there is little need for any general purpose perm element, Indeed I could only come up with one use case for the perm field and that is to restrict or forbid further layers of delegated identifiers. This sort of constraint can easily be provided using a trait via the inception cnfg element.

3) Not having having a cnfg element in the delegated inception meant that we could not constrain delegated event streams to establishment only. An establishment only event stream is the most secure as each key set is one time use only for signing. This makes key exploit extremely difficult as one must compromise the next keys to do so which have never been exposed.   This makes delegation coordination more difficult but with some multi-level delegations more than one level at the top may benefit form establishment only in spite of the increased difficulty.

4) A perm element in the delegated rotation would complicate validation of permission constraints. Instead of one fixed set of permissions at inception, each rotation could change the permissions. This would make validation much more difficult as any validator would have to track those changes over events. This makes the validation logic and key state logic for delegated rotation much more complicated than non delegated rotations and only makes sense if generic authorizations need support. Given 1)  above this is better served by  VC authorizations.

5) Not having a data element in a delegated rotation means that a delegation cannot be performed in  rotation. This means that an establishment only delegated identifier could not subsequently delegate. With a data element then delegated rotations can also do delegations. This makes 3) more useful.

Overall the changes simplify the delegated event logic and  make the delegated event logic and non-delegated event syntax and logic more similar and therefore easier to maintain.  Recognizing the role of verifiable credentials play in providing flexible, extensible, authorizations means that KERI can focus on the key management and only use delegation for delegating key management infrastructure not the forms of authorizations.
