### PR TITLE
Update ksn message samples in DID method spec

### DIFF
--- a/did_methods/index.html
+++ b/did_methods/index.html
@@ -57,6 +57,12 @@
                     authors: ["S. Smith"],
                     publisher: "Decentralized Identity Foundation"
                 },
+                KID0008: {
+                    title: "KID0008 - Key-Event State Machine",
+                    href: "https://github.com/decentralized-identity/keri/blob/master/kids/kid0008.md",
+                    authors: ["S. Smith"],
+                    publisher: "Decentralized Identity Foundation"
+                },
                 KID0009: {
                     title: "KID0009 - Indirect Mode & Witnesses",
                     href: "https://github.com/decentralized-identity/keri/blob/master/kids/kid0009.md",
@@ -161,116 +167,24 @@
             </ul>
 
         <p>
-            Key state notification messages differ depending on the transferability of the the prefix signer and whether
+            Key state notification messages differ depending on whether
             the signer is using a delegated identifier.  The follow examples detail the fields needed for each permutation.
         </p>
 
-        <pre class="example highlight" title="Non-transferable Prefix Signer Key State Message">
+        <pre class="example highlight" title="Key State Message">
             {
               "v": "KERI10JSON00011c_",
               "i": "EaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",
+              "s": "2",
               "t": "ksn",
+              "d": "EAoTNZH3ULvaU6JR2nmwyYAfSVPzhzZ-i0d8JZS6b5CM",
+              "te": "rot",
               "kt": "1",
               "k": ["DaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM"],
               "n": "EZ-i0d8JZAoTNZH3ULvaU6JR2nmwyYAfSVPzhzS6b5CM",
               "wt": "1",
               "w": ["DnmwyYAfSVPzhzS6b5CMZ-i0d8JZAoTNZH3ULvaU6JR2"],
               "c": ["eo"],
-              "e":
-                {
-                  "s": "2",
-                  "t": "rot",
-                  "d": "EAoTNZH3ULvaU6JR2nmwyYAfSVPzhzZ-i0d8JZS6b5CM",
-                },
-              "ee":
-                {
-                  "s": "1",
-                  "d": "EAoTNZH3ULvaU6JR2nmwyYAfSVPzhzZ-i0d8JZS6b5CM",
-                  "wr": ["Dd8JZAoTNZH3ULvaU6JR2nmwyYAfSVPzhzS6b5CMZ-i0"],
-                  "wa": ["DnmwyYAfSVPzhzS6b5CMZ-i0d8JZAoTNZH3ULvaU6JR2"]
-                },
-              "di": "",
-              "a": {}
-            }
-        </pre>
-        <pre class="example highlight" title="Delegated Non-transferable Prefix Signer Key State Message">
-            {
-              "v": "KERI10JSON00011c_",
-              "i": "EaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",
-              "t": "ksn",
-              "kt": "1",
-              "k": ["DaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM"],
-              "n": "EZ-i0d8JZAoTNZH3ULvaU6JR2nmwyYAfSVPzhzS6b5CM",
-              "wt": "1",
-              "w": ["DnmwyYAfSVPzhzS6b5CMZ-i0d8JZAoTNZH3ULvaU6JR2"],
-              "c": ["eo"],
-              "e":
-                {
-                  "s": "2",
-                  "t": "rot",
-                  "d": "EAoTNZH3ULvaU6JR2nmwyYAfSVPzhzZ-i0d8JZS6b5CM",
-                },
-              "ee":
-                {
-                  "s": "1",
-                  "d": "EAoTNZH3ULvaU6JR2nmwyYAfSVPzhzZ-i0d8JZS6b5CM",
-                  "wr": ["Dd8JZAoTNZH3ULvaU6JR2nmwyYAfSVPzhzS6b5CMZ-i0"],
-                  "wa": ["DnmwyYAfSVPzhzS6b5CMZ-i0d8JZAoTNZH3ULvaU6JR2"]
-                },
-              "di": "EJZAoTNZH3ULvYAfSVPzhzS6b5CMaU6JR2nmwyZ-i0d8"
-              "a": {}
-            }
-        </pre>
-        <pre class="example highlight" title="Transferable Prefix Signer Key State Message">
-            {
-              "v": "KERI10JSON00011c_",
-              "i": "EaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",
-              "t": "ksn",
-              "kt": "1",
-              "k": ["DaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM"],
-              "n": "EZ-i0d8JZAoTNZH3ULvaU6JR2nmwyYAfSVPzhzS6b5CM",
-              "wt": "1",
-              "w": ["DnmwyYAfSVPzhzS6b5CMZ-i0d8JZAoTNZH3ULvaU6JR2"],
-              "c": ["eo"],
-              "e":
-                {
-                  "s": "2",
-                  "t": "rot",
-                  "d": "EAoTNZH3ULvaU6JR2nmwyYAfSVPzhzZ-i0d8JZS6b5CM",
-                },
-              "ee":
-                {
-                  "s": "1",
-                  "d": "EAoTNZH3ULvaU6JR2nmwyYAfSVPzhzZ-i0d8JZS6b5CM",
-                  "wr": ["Dd8JZAoTNZH3ULvaU6JR2nmwyYAfSVPzhzS6b5CMZ-i0"],
-                  "wa": ["DnmwyYAfSVPzhzS6b5CMZ-i0d8JZAoTNZH3ULvaU6JR2"]
-                },
-              "di": "",
-              "a":
-                {
-                  "i": "EJZAoTNZH3ULvYAfSVPzhzS6b5aU6JR2nmwyZ-i0d8CM",
-                  "s": "1",
-                  "d": "EULvaU6JR2nmwyAoTNZH3YAfSVPzhzZ-i0d8JZS6b5CM"
-                }
-            }
-        </pre>
-        <pre class="example highlight" title="Delegated Transferable Prefix Signer Key State Message">
-            {
-              "v": "KERI10JSON00011c_",
-              "i": "EaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",
-              "t": "ksn",
-              "kt": "1",
-              "k": ["DaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM"],
-              "n": "EZ-i0d8JZAoTNZH3ULvaU6JR2nmwyYAfSVPzhzS6b5CM",
-              "wt": "1",
-              "w": ["DnmwyYAfSVPzhzS6b5CMZ-i0d8JZAoTNZH3ULvaU6JR2"],
-              "c": ["eo"],
-              "e":
-                {
-                  "s": "2",
-            	  "t": "rot",
-                  "d": "EAoTNZH3ULvaU6JR2nmwyYAfSVPzhzZ-i0d8JZS6b5CM",
-                },
               "ee":
                 {
                   "s":  "1",
@@ -278,14 +192,33 @@
                   "wr": ["Dd8JZAoTNZH3ULvaU6JR2nmwyYAfSVPzhzS6b5CMZ-i0"],
                   "wa": ["DnmwyYAfSVPzhzS6b5CMZ-i0d8JZAoTNZH3ULvaU6JR2"]
                 },
-              "di": "EJZAoTNZH3ULvYAfSVPzhzS6b5CMaU6JR2nmwyZ-i0d8",
-              "a":
+              "di": "EJZAoTNZH3ULvYAfSVPzhzS6b5CMaU6JR2nmwyZ-i0d8"
+            }
+        </pre>
+        <pre class="example highlight" title="Delegated Key State Message">
+            {
+              "v": "KERI10JSON00011c_",
+              "i": "EaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM",
+              "s": "2",
+              "t": "ksn",
+              "d": "EAoTNZH3ULvaU6JR2nmwyYAfSVPzhzZ-i0d8JZS6b5CM",
+              "te": "rot",
+              "kt": "1",
+              "k": ["DaU6JR2nmwyZ-i0d8JZAoTNZH3ULvYAfSVPzhzS6b5CM"],
+              "n": "EZ-i0d8JZAoTNZH3ULvaU6JR2nmwyYAfSVPzhzS6b5CM",
+              "wt": "1",
+              "w": ["DnmwyYAfSVPzhzS6b5CMZ-i0d8JZAoTNZH3ULvaU6JR2"],
+              "c": ["eo"],
+              "ee":
                 {
-                  "i":  "EJZAoTNZH3ULvYAfSVPzhzS6b5aU6JR2nmwyZ-i0d8CM",
                   "s":  "1",
-                  "d":  "EULvaU6JR2nmwyAoTNZH3YAfSVPzhzZ-i0d8JZS6b5CM"
-                }
-            }        </pre>
+                  "d":  "EAoTNZH3ULvaU6JR2nmwyYAfSVPzhzZ-i0d8JZS6b5CM",
+                  "wr": ["Dd8JZAoTNZH3ULvaU6JR2nmwyYAfSVPzhzS6b5CMZ-i0"],
+                  "wa": ["DnmwyYAfSVPzhzS6b5CMZ-i0d8JZAoTNZH3ULvaU6JR2"]
+                },
+              "di": "EJZAoTNZH3ULvYAfSVPzhzS6b5CMaU6JR2nmwyZ-i0d8"
+            }
+        </pre>
     </section>
     <section class="normative" id="resolvermetadata">
         <h3>Resolver Metadata</h3>
@@ -400,7 +333,7 @@
                 this specification.  Possible implementations include the use of a Distributed Hash Table (DHT), anchoring a KEL in a ledger or the use of a gossip
                 protocol involving a witness network.
             </li>
-            <li>Process the KEL into a Key State, according to the state validation rules/semantics of KERI as defined in [[KERI]]
+            <li>Process the KEL into a Key State, according to the state validation rules/semantics of KERI as defined in [[KID0008]]
             </li>
             <li>Create a DID Document with the DID `did:keri:$PREF`</li>
             <li>For each key K in the Key State, add a Verification Method to the DID Doc containing K and the


### PR DESCRIPTION
This PR includes:

* Update ksn message samples to match changes to KID0003 for new complex grouping code.

* Remove normative reference to the white paper.

This PR closes #138 

Signed-off-by: Phil Feairheller <pfeairheller@gmail.com>